### PR TITLE
Squeue format

### DIFF
--- a/src/slurm_api_cli_proxy/client_args_linker/v39/slurm_api_client_wrapper_v39.py
+++ b/src/slurm_api_cli_proxy/client_args_linker/v39/slurm_api_client_wrapper_v39.py
@@ -160,13 +160,13 @@ def format_squeue_job(job:V0039JobInfo,job_resources:V0039JobRes):
     else:        
         elapsed_time = str(seconds_to_hhmm(timestamp-job.start_time)) if job.job_state == "RUNNING" else "00:00"
     return (
-        f"{str(job.job_id)[:5]:5} "
-        f"{str(job.partition)[:9]:9} "
-        f"{str(job.name)[:8]:8} "
-        f"{str(job.user_name)[:8]:8} "
-        f"{job_status[:8]:8} "
-        f"{elapsed_time[:5]:5} "
-        f"{str(job_resources.allocated_hosts)[:5]:5} "
+        f"{str(job.job_id)[:5]:>5} "
+        f"{str(job.partition)[:9]:>9} "
+        f"{str(job.name)[:8]:>8} "
+        f"{str(job.user_name)[:8]:>8} "
+        f"{job_status[:8]:>8} "
+        f"{elapsed_time[:5]:>5} "
+        f"{str(job_resources.allocated_hosts)[:5]:>5} "
         f"{job_resources.nodes}\n"
     )
 

--- a/src/slurm_api_cli_proxy/client_args_linker/v39/slurm_api_client_wrapper_v39.py
+++ b/src/slurm_api_cli_proxy/client_args_linker/v39/slurm_api_client_wrapper_v39.py
@@ -152,20 +152,21 @@ def format_squeue_job(job:V0039JobInfo,job_resources:V0039JobRes):
     if job.job_state is None:
         job_status:str = "??"
     else:
-        job_status = slurm_statuses[job.job_state]
+        job_status = slurm_statuses[job.job_state].rjust(2, ' ')
 
+    print("===", "\njob.job_state:", job.job_state, "\njob_status", job_status)
 
     if job.start_time is None:
-        elapsed_time:str = "00:00"
+        elapsed_time:str = " 0:00"
     else:        
-        elapsed_time = str(seconds_to_hhmm(timestamp-job.start_time)) if job.job_state == "RUNNING" else "00:00"
+        elapsed_time = str(seconds_to_hhmm(timestamp-job.start_time)) if job.job_state == "RUNNING" else " 0:00"
     return (
         f"{str(job.job_id)[:5]:>5} "
         f"{str(job.partition)[:9]:>9} "
         f"{str(job.name)[:8]:>8} "
         f"{str(job.user_name)[:8]:>8} "
-        f"{job_status[:8]:>8} "
-        f"{elapsed_time[:5]:>5} "
+        f"{job_status[:8]:7} "
+        f"{elapsed_time[:5]:>6} "
         f"{str(job_resources.allocated_hosts)[:5]:>5} "
         f"{job_resources.nodes}\n"
     )
@@ -183,4 +184,4 @@ def seconds_to_hhmm(seconds):
     """
     minutes = seconds // 60
     remaining_seconds = seconds % 60
-    return f"{minutes:02d}:{remaining_seconds:02d}"
+    return f"{minutes:2d}:{remaining_seconds:02d}"

--- a/src/slurm_api_cli_proxy/client_args_linker/v39/slurm_api_client_wrapper_v39.py
+++ b/src/slurm_api_cli_proxy/client_args_linker/v39/slurm_api_client_wrapper_v39.py
@@ -154,8 +154,6 @@ def format_squeue_job(job:V0039JobInfo,job_resources:V0039JobRes):
     else:
         job_status = slurm_statuses[job.job_state].rjust(2, ' ')
 
-    print("===", "\njob.job_state:", job.job_state, "\njob_status", job_status)
-
     if job.start_time is None:
         elapsed_time:str = " 0:00"
     else:        

--- a/src/tests/v39/test_v39_squeue_formatting.py
+++ b/src/tests/v39/test_v39_squeue_formatting.py
@@ -2,7 +2,7 @@ import pytest
 from slurm_api_cli_proxy.client_args_linker.v39.slurm_api_client_wrapper_v39 import format_squeue_job, V0039JobInfo, V0039JobRes, slurm_statuses
 import time
 
-def test_format_squeue_job():
+def test_format_squeue_job_fields():
     job_info = V0039JobInfo(
         job_id=12345,
         partition="partition1",
@@ -22,4 +22,22 @@ def test_format_squeue_job():
     assert slurm_statuses["RUNNING"] in result
     assert "30:00" in result  # 30 min elapsed
     assert "node1" in result
+
+def test_format_squeue_job_alignment():
+    job_info = V0039JobInfo(
+        job_id=123,
+        partition="ptn1",
+        name="testjob",
+        user_name="user1",
+        job_state="RUNNING",
+        start_time=int(time.time()) - 1800,  # 30 min ago
+        job_resources=V0039JobRes(allocated_hosts=1, nodes="node1")
+    )
+    job_resources = V0039JobRes(allocated_hosts=1, nodes="node1")
+
+    result = format_squeue_job(job_info, job_resources)
+    expected = "  123      ptn1  testjob    user1        R 30:00     1 node1\n"
+
+    assert result == expected, f"Formatted output should be \"{expected}\""
+
 

--- a/src/tests/v39/test_v39_squeue_formatting.py
+++ b/src/tests/v39/test_v39_squeue_formatting.py
@@ -23,6 +23,9 @@ def test_format_squeue_job_fields():
     assert "30:00" in result  # 30 min elapsed
     assert "node1" in result
 
+# TODO We might also want to test if the field content truncation behaviour
+# is consistent with the SLURM CLI
+
 def test_format_squeue_job_alignment():
     job_info = V0039JobInfo(
         job_id=123,

--- a/src/tests/v39/test_v39_squeue_formatting.py
+++ b/src/tests/v39/test_v39_squeue_formatting.py
@@ -9,7 +9,7 @@ def test_format_squeue_job_fields():
         name="test_job",
         user_name="user1",
         job_state="RUNNING",
-        start_time=int(time.time()) - 1800,  # 30 min ago
+        start_time=int(time.time()) - 1800, # 30 min ago
         job_resources=V0039JobRes(allocated_hosts=1, nodes="node1")
     )
     job_resources = V0039JobRes(allocated_hosts=1, nodes="node1")
@@ -33,14 +33,14 @@ def test_format_squeue_job_alignment():
         name="testjob",
         user_name="user1",
         job_state="RUNNING",
-        start_time=int(time.time()) - 1800,  # 30 min ago
+        start_time=int(time.time()) - 120,  # 2 min ago
         job_resources=V0039JobRes(allocated_hosts=1, nodes="node1")
     )
     job_resources = V0039JobRes(allocated_hosts=1, nodes="node1")
 
     result = format_squeue_job(job_info, job_resources)
-    expected = "  123      ptn1  testjob    user1        R 30:00     1 node1\n"
+    expected = "  123      ptn1  testjob    user1  R        2:00     1 node1\n"
 
-    assert result == expected, f"Formatted output should be \"{expected}\""
+    assert result == expected, f"Formatted output should be \"{expected}\" but was \"{result}\""
 
 


### PR DESCRIPTION
Hi @hcadavid,

I have added one test and changed the formatting code a little.
When comparing "local" squeue output on Snellius and squeue output of the proxy, I noticed a few subtle differences that I addressed:
The two-letter abbreviation of the Status is left-padded with a space and for the rest left-aligened.
The minutes of the "elapsed" time do not have a leading zero when less than 10 minutes. Instead, they are left-padded with space, too.
Truncation seems to work the same for both outouts.
I think that this is very reasonable for now. If other subtle differences show up, I know where to address them.

Should I, as another assignment, enable the proxy to "understand" an squeue-call as issued by Galaxy Pulsar?

`squeue -a -o '%A %t' -j myjob`

